### PR TITLE
Update setup_mac.sh

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -94,7 +94,7 @@ else
 fi
 
 # Install dependencies
-pip install -r requirements.txt
+conda install -r requirements.txt
 
 pip install git+https://github.com/openai/CLIP.git@d50d76daa670286dd6cacf3bcd80b5e4823fc8e1
 

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -92,9 +92,14 @@ else
     echo "============================================="
     exit 1
 fi
+# There's an issue that onnx, dependency of invisible-watermark, is not properly installed on the M1 silicons.
+# it is still opened    https://github.com/onnx/onnx/issues/3129  
+# Therefore we should install onnx with conda instead of pip in prior to installing with pip.
+# Otherwise other dependencies would be skipped without being installed.
+conda install onnx
 
 # Install dependencies
-conda install -r requirements.txt
+pip install -r requirements.txt
 
 pip install git+https://github.com/openai/CLIP.git@d50d76daa670286dd6cacf3bcd80b5e4823fc8e1
 


### PR DESCRIPTION
There's an issue that onnx, dependency of invisible-watermark, cannot be properly installed on the M1 silicons.
And it is still opened    https://github.com/onnx/onnx/issues/3129  
Therefore we should install onnx with conda instead of pip in prior to installing with pip.
Otherwise other dependencies would be skipped without being installed.