### PR TITLE
Use MPS for upscalers

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -162,7 +162,7 @@ conda activate web-ui
 git pull --rebase
 
 # Run the web ui
-python webui.py --precision full --no-half --use-cpu Interrogate GFPGAN CodeFormer BSRGAN ESRGAN SCUNet \$@
+python webui.py --precision full --no-half --use-cpu Interrogate GFPGAN CodeFormer \$@
 
 # Deactivate conda environment
 conda deactivate
@@ -187,6 +187,6 @@ echo "============================================="
 
 
 # Run the web UI
-python webui.py --precision full --no-half --use-cpu Interrogate GFPGAN CodeFormer BSRGAN ESRGAN SCUNet
+python webui.py --precision full --no-half --use-cpu Interrogate GFPGAN CodeFormer
 
 


### PR DESCRIPTION
`--use-cpu` was used for most upscalers due to generating incorrect output on MPS, but that has been fixed by faed465a0b1a7d19669568738c93e04907c10415

Also fixes run_webui_mac.sh not working due to the removal of BSRGAN.